### PR TITLE
fix: remove_owner for non-existent owner

### DIFF
--- a/bin/node-template/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node-template/pallets/pallet-ipfs/src/lib.rs
@@ -154,6 +154,8 @@ pub mod pallet {
 			);
 
 			let mut ipfs = Self::ipfs_asset(&ipfs_id).ok_or(<Error<T>>::IpfsNotExist)?;
+			ensure!(ipfs.owners.contains_key(&remove_acct), <Error<T>>::AccNotExist);
+
 			ipfs.owners.remove(&remove_acct);
 
 			<IpfsAsset<T>>::insert(&ipfs_id, ipfs);


### PR DESCRIPTION
`remove_owner` extrinsic now only removes **existing** owners