### PR TITLE
Minor fixes

### DIFF
--- a/bin/node-template/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node-template/pallets/pallet-ipfs/src/lib.rs
@@ -51,6 +51,7 @@ pub use weights::WeightInfo;
 #[derive(Encode, Decode, RuntimeDebug, PartialEq, TypeInfo)]
 pub enum DataCommand<AccountId> {
 	AddBytes(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
+	AddBytesRaw(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
 	CatBytes(OpaqueMultiaddr, Vec<u8>, AccountId),
 	InsertPin(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
 	RemovePin(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
@@ -229,30 +230,48 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Create a new unique IPFS.
-		///
-		/// The actual IPFS creation is done in the `mint()` function.
 		#[pallet::weight(T::WeightInfo::create_ipfs_asset())]
 		pub fn create_ipfs_asset(
 			origin: OriginFor<T>,
 			addr: Vec<u8>,
-			ci_address: Vec<u8>,
+			cid: Vec<u8>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
 			ensure!(
-				!<IpfsAssetOwned<T>>::get(&sender).contains(&ci_address),
+				!<IpfsAssetOwned<T>>::get(&sender).contains(&cid),
 				<Error<T>>::IpfsAlreadyOwned
 			);
 
 			let multiaddr = OpaqueMultiaddr(addr);
 
 			<DataQueue<T>>::mutate(|queue| {
-				queue.push(DataCommand::AddBytes(
-					multiaddr,
-					ci_address.clone(),
-					sender.clone(),
-					true,
-				))
+				queue.push(DataCommand::AddBytes(multiaddr, cid.clone(), sender.clone(), true))
+			});
+
+			Self::deposit_event(Event::QueuedDataToAdd(sender.clone()));
+
+			Ok(())
+		}
+
+		/// Create a new unique IPFS.
+		#[pallet::weight(T::WeightInfo::create_ipfs_asset())]
+		pub fn create_ipfs_asset_raw(
+			origin: OriginFor<T>,
+			addr: Vec<u8>,
+			data: Vec<u8>,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+
+			ensure!(
+				!<IpfsAssetOwned<T>>::get(&sender).contains(&data),
+				<Error<T>>::IpfsAlreadyOwned
+			);
+
+			let multiaddr = OpaqueMultiaddr(addr);
+
+			<DataQueue<T>>::mutate(|queue| {
+				queue.push(DataCommand::AddBytesRaw(multiaddr, data.clone(), sender.clone(), true))
 			});
 
 			Self::deposit_event(Event::QueuedDataToAdd(sender.clone()));
@@ -570,7 +589,7 @@ pub mod pallet {
 					} else {
 						Err(<Error<T>>::AccNotExist)
 					}
-				}
+				},
 				None => Err(<Error<T>>::IpfsNotExist),
 			}
 		}
@@ -672,7 +691,7 @@ pub mod pallet {
 													Ok(()) => {
 														// also this probably doesn't work.
 														log::info!("Submited IPFS results")
-													}
+													},
 													Err(e) => log::error!(
 														"Failed to submit transaction: {:?}",
 														e
@@ -690,10 +709,10 @@ pub mod pallet {
 														sp_std::str::from_utf8(&cid)
 															.expect("trusted")
 													)
-												}
+												},
 												Ok(_) => {
 													unreachable!("only Success can be a response for that request type")
-												}
+												},
 												Err(e) => log::error!("IPFS: Pin Error: {:?}", e),
 											}
 
@@ -703,21 +722,21 @@ pub mod pallet {
 											) {
 												Ok(IpfsResponse::Success) => {
 													log::info!("IPFS: Disconeccted Succes")
-												}
+												},
 												Ok(_) => {
 													unreachable!("only Success can be a response for that request type")
-												}
+												},
 												Err(e) => {
 													log::error!("IPFS: Disconnect Error: {:?}", e)
-												}
+												},
 											}
-										}
+										},
 										Ok(_) => unreachable!(
 											"only AddBytes can be a response for that request type"
 										),
 										Err(e) => log::error!("IPFS: Add Error: {:?}", e),
 									}
-								}
+								},
 								Ok(_) => unreachable!(
 									"only AddBytes can be a response for that request type."
 								),
@@ -728,7 +747,95 @@ pub mod pallet {
 							),
 							Err(e) => log::error!("IPFS: add error: {:?}", e),
 						}
-					}
+					},
+
+					DataCommand::AddBytesRaw(m_addr, data, admin, is_recursive) => {
+						// this should work for different CID's. If you try to
+						// connect and upload the same CID, you will get a duplicate
+						// conn error. @charmitro
+						match Self::ipfs_request(IpfsRequest::Connect(m_addr.clone()), deadline) {
+							Ok(IpfsResponse::Success) => match Self::ipfs_request(
+								IpfsRequest::AddBytes(data.clone()),
+								deadline,
+							) {
+								Ok(IpfsResponse::AddBytes(cid)) => {
+									log::info!("IPFS: added data");
+									Self::ipfs_request(
+										IpfsRequest::Disconnect(m_addr.clone()),
+										deadline,
+									)?;
+
+									// signer is the probably the node account (often Alice)
+									let signer = Signer::<T, T::AuthorityId>::all_accounts();
+									if !signer.can_sign() {
+										log::error!(
+												"No local account available. Consider adding one via `author_insertKey` RPC.",
+											);
+									}
+
+									let results = signer.send_signed_transaction(|_account| {
+										Call::submit_ipfs_add_results {
+											// admin should be the actual account that we is doing
+											// the transcation in the first place(create_ipfs_asset)
+											admin: admin.clone(),
+											cid: cid.clone(),
+										}
+									});
+
+									for (_, res) in &results {
+										match res {
+											Ok(()) => {
+												// also this probably doesn't work.
+												log::info!("Submited IPFS results")
+											},
+											Err(e) => {
+												log::error!("Failed to submit transaction: {:?}", e)
+											},
+										}
+									}
+
+									match Self::ipfs_request(
+										IpfsRequest::InsertPin(cid.clone(), is_recursive),
+										deadline,
+									) {
+										Ok(IpfsResponse::Success) => {
+											log::info!(
+												"IPFS: pinned data with CID: {}",
+												sp_std::str::from_utf8(&cid).expect("trusted")
+											)
+										},
+										Ok(_) => {
+											unreachable!("only Success can be a response for that request type")
+										},
+										Err(e) => log::error!("IPFS: Pin Error: {:?}", e),
+									}
+
+									match Self::ipfs_request(
+										IpfsRequest::Disconnect(m_addr.clone()),
+										deadline,
+									) {
+										Ok(IpfsResponse::Success) => {
+											log::info!("IPFS: Disconeccted Succes")
+										},
+										Ok(_) => {
+											unreachable!("only Success can be a response for that request type")
+										},
+										Err(e) => {
+											log::error!("IPFS: Disconnect Error: {:?}", e)
+										},
+									}
+								},
+								Ok(_) => unreachable!(
+									"only AddBytes can be a response for that request type."
+								),
+								Err(e) => log::error!("IPFS: add error: {:?}", e),
+							},
+							Ok(_) => unreachable!(
+								"only AddBytes can be a response for that request type."
+							),
+							Err(e) => log::error!("IPFS: add error: {:?}", e),
+						}
+					},
 
 					DataCommand::CatBytes(m_addr, cid, _admin) => {
 						match Self::ipfs_request(IpfsRequest::CatBytes(cid.clone()), deadline) {
@@ -744,13 +851,13 @@ pub mod pallet {
 									sp_std::str::from_utf8(&m_addr.0)
 										.expect("our own calls can be trusted to be UTF-8; qed")
 								);
-							}
+							},
 							Ok(_) => unreachable!(
 								"only AddBytes can be a response for that request type."
 							),
 							Err(e) => log::error!("IPFS: add error: {:?}", e),
 						}
-					}
+					},
 
 					DataCommand::InsertPin(_m_addr, cid, _admin, is_recursive) => {
 						match Self::ipfs_request(
@@ -778,19 +885,19 @@ pub mod pallet {
 									match res {
 										Ok(()) => {
 											log::info!("Submited IPFS results")
-										}
+										},
 										Err(e) => {
 											log::error!("Failed to submit transaction: {:?}", e)
-										}
+										},
 									}
 								}
-							}
+							},
 							Ok(_) => {
 								unreachable!("only Success can be a response for that request type")
-							}
+							},
 							Err(e) => log::error!("IPFS: Pin Error: {:?}", e),
 						}
-					}
+					},
 
 					DataCommand::RemovePin(_m_addr, cid, _admin, is_recursive) => {
 						match Self::ipfs_request(
@@ -818,19 +925,19 @@ pub mod pallet {
 									match res {
 										Ok(()) => {
 											log::info!("Submited IPFS results")
-										}
+										},
 										Err(e) => {
 											log::error!("Failed to submit transaction: {:?}", e)
-										}
+										},
 									}
 								}
-							}
+							},
 							Ok(_) => {
 								unreachable!("only Success can be a response for that request type")
-							}
+							},
 							Err(e) => log::error!("IPFS: Remove Pin Error: {:?}", e),
 						}
-					}
+					},
 
 					DataCommand::RemoveBlock(_m_addr, cid, _admin) => {
 						match Self::ipfs_request(IpfsRequest::RemoveBlock(cid.clone()), deadline) {
@@ -855,19 +962,19 @@ pub mod pallet {
 									match res {
 										Ok(()) => {
 											log::info!("Submited IPFS results")
-										}
+										},
 										Err(e) => {
 											log::error!("Failed to submit transaction: {:?}", e)
-										}
+										},
 									}
 								}
-							}
+							},
 							Ok(_) => unreachable!(
 								"only RemoveBlock can be a response for that request type"
 							),
 							Err(e) => log::error!("IPFS: Remove Block Error: {:?}", e),
 						}
-					}
+					},
 				}
 			}
 			Ok(())

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 103,
+	spec_version: 104,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -498,7 +498,7 @@ where
 	fn import(&self, transaction: B::Extrinsic) -> TransactionImportFuture {
 		if !self.imports_external_transactions {
 			debug!("Transaction rejected");
-			Box::pin(futures::future::ready(TransactionImport::None));
+			let _unused = Box::pin(futures::future::ready(TransactionImport::None));
 		}
 
 		let encoded = transaction.encode();

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -137,7 +137,7 @@ pub struct OffchainState {
 	/// List of pending IPFS requests
 	pub ipfs_requests: BTreeMap<IpfsRequestId, IpfsPendingRequest>,
 	/// Map of  requests that the test is expected to perform
-	expected_ipfs_requests: BTreeMap<IpfsRequestId, IpfsPendingRequest>,
+	_expected_ipfs_requests: BTreeMap<IpfsRequestId, IpfsPendingRequest>,
 	/// Persistent local storage
 	pub persistent_storage: TestPersistentOffchainDB,
 	/// Local storage


### PR DESCRIPTION
1. Clean-up rustc warnings
2. Added new call `create_ipfs_asset_raw` that supports small files(e.g. text files, code and more)