### PR TITLE
Ipfs pin fixes

### DIFF
--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -159,6 +159,8 @@ pub mod pallet {
 		IpfsAlreadyOwned,
 		/// Ensures that an IPFS is not already pinned.
 		IpfsAlreadyPinned,
+		/// Ensures that an IPFS is pinned.
+		IpfsNotPinned,
 		CantCreateRequest,
 		RequestTimeout,
 		RequestFailed,
@@ -349,6 +351,11 @@ pub mod pallet {
 			);
 
 			let multiaddr = OpaqueMultiaddr(addr);
+			let ipfs_asset = Self::ipfs_asset(&cid).ok_or(<Error<T>>::IpfsNotExist)?;
+
+			ensure!(
+				ipfs_asset.pinned == true, <Error<T>>::IpfsNotPinned
+			);
 
 			<DataQueue<T>>::mutate(|queue| {
 				queue.push(DataCommand::RemovePin(multiaddr, cid.clone(), sender.clone(), true))

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -381,7 +381,14 @@ pub mod pallet {
 			);
 
 			let multiaddr = OpaqueMultiaddr(addr);
+			let ipfs_asset = Self::ipfs_asset(&cid).ok_or(<Error<T>>::IpfsNotExist)?;
 
+			if ipfs_asset.pinned == true {
+				<DataQueue<T>>::mutate(|queue| {
+					queue.push(DataCommand::RemovePin(multiaddr.clone(), cid.clone(), sender.clone(), true))
+				});
+			}
+		
 			<DataQueue<T>>::mutate(|queue| {
 				queue.push(DataCommand::RemoveBlock(multiaddr, cid.clone(), sender.clone()))
 			});


### PR DESCRIPTION
Fix: pin_ipfs_asset was pinning an asset that was already pinned. Added IpfsAlreadyPinned Error to ensure that only unpinned assets can be pinned.

Fix: unpin_ipfs_asset was removing the pin of an asset that wasn't pinned. Added IpfsNotPinned Error to ensure that only pinned assets can get their pin removed.

Fix: Delete_ipfs_asset couldn't delete a pinned asset. I added the RemovePin DataCommand so that the delete_ipfs_asset function removes the pin first (if the file is pinned. If the file is not pinned, it skips that step) and then deletes the block.