### PR TITLE
Pallet updater genesis --- added genesis config, genesis build, genesis default, added genesis config runtime to chainspec --- runs successfully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6349,6 +6349,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log 0.4.14",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
 
 pub use node_primitives::{AccountId, Balance, Signature};
 pub use node_runtime::GenesisConfig;
-
+use sp_core::crypto::Ss58Codec;
 type AccountPublic = <Signature as Verify>::Signer;
 
 const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -356,7 +356,7 @@ pub fn testnet_genesis(
 		treasury: Default::default(),
 		updater: UpdaterConfig {
 			phantom: Default::default(),
-			members: vec![],
+			members: vec![AccountId::from_ss58check("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap()],
 		},
 		society: SocietyConfig {
 			members: endowed_accounts

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -356,10 +356,10 @@ pub fn testnet_genesis(
 		treasury: Default::default(),
 		updater: UpdaterConfig {
 			phantom: Default::default(),
-			members: vec![AccountId::from_ss58check("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap(),
-						AccountId::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap(),
-						AccountId::from_ss58check("5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y").unwrap(),	
-						AccountId::from_ss58check("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap(),		],
+			members: vec![AccountId::from_ss58check("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap() /// ALICE,
+						AccountId::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap() /// BOB,
+						AccountId::from_ss58check("5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y").unwrap() /// CHARLIE,	
+						AccountId::from_ss58check("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap() /// DAVE,		],
 		},
 		society: SocietyConfig {
 			members: endowed_accounts

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -356,7 +356,10 @@ pub fn testnet_genesis(
 		treasury: Default::default(),
 		updater: UpdaterConfig {
 			phantom: Default::default(),
-			members: vec![AccountId::from_ss58check("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap()],
+			members: vec![AccountId::from_ss58check("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY").unwrap(),
+						AccountId::from_ss58check("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap(),
+						AccountId::from_ss58check("5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y").unwrap(),	
+						AccountId::from_ss58check("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap(),		],
 		},
 		society: SocietyConfig {
 			members: endowed_accounts

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -22,7 +22,7 @@ use grandpa_primitives::AuthorityId as GrandpaId;
 use hex_literal::hex;
 use node_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AssetsConfig, AuthorityDiscoveryConfig, BabeConfig,
-	BalancesConfig, Block, CouncilConfig, ElectionsConfig, GrandpaConfig, PalletUpdaterConfig,
+	BalancesConfig, Block, CouncilConfig, ElectionsConfig, GrandpaConfig, UpdaterConfig,
 	ImOnlineConfig, IndicesConfig, SessionConfig, SessionKeys, SocietyConfig, StakerStatus,
 	StakingConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, MAX_NOMINATIONS,
 };
@@ -67,7 +67,6 @@ pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 pub fn flaming_fir_config() -> Result<ChainSpec, String> {
 	ChainSpec::from_json_bytes(&include_bytes!("../res/flaming-fir.json")[..])
 }
-
 fn session_keys(
 	grandpa: GrandpaId,
 	babe: BabeId,
@@ -355,8 +354,9 @@ pub fn testnet_genesis(
 		grandpa: GrandpaConfig { authorities: vec![] },
 		technical_membership: Default::default(),
 		treasury: Default::default(),
-		pallet_updater: PalletUpdaterConfig {
-			members: vec![]
+		updater: UpdaterConfig {
+			phantom: Default::default(),
+			members: vec![],
 		},
 		society: SocietyConfig {
 			members: endowed_accounts

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -22,7 +22,7 @@ use grandpa_primitives::AuthorityId as GrandpaId;
 use hex_literal::hex;
 use node_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AssetsConfig, AuthorityDiscoveryConfig, BabeConfig,
-	BalancesConfig, Block, CouncilConfig, ElectionsConfig, GrandpaConfig,
+	BalancesConfig, Block, CouncilConfig, ElectionsConfig, GrandpaConfig, PalletUpdaterConfig,
 	ImOnlineConfig, IndicesConfig, SessionConfig, SessionKeys, SocietyConfig, StakerStatus,
 	StakingConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, MAX_NOMINATIONS,
 };
@@ -355,6 +355,9 @@ pub fn testnet_genesis(
 		grandpa: GrandpaConfig { authorities: vec![] },
 		technical_membership: Default::default(),
 		treasury: Default::default(),
+		pallet_updater: PalletUpdaterConfig {
+			members: vec![]
+		},
 		society: SocietyConfig {
 			members: endowed_accounts
 				.iter()

--- a/bin/node/pallets/pallet-updater/Cargo.toml
+++ b/bin/node/pallets/pallet-updater/Cargo.toml
@@ -13,6 +13,7 @@ frame-support = { version = "4.0.0-dev", default-features = false, path = "../..
 frame-system = { version = "4.0.0-dev", default-features = false, path = "../../../../frame/system" }
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, path = "../../../../frame/benchmarking", optional = true }
 sp-std = { version = "4.0.0-dev", default-features = false, path = "../../../../primitives/std" }
+log = { version = "0.4.14", default-features = false }
 
 [dev-dependencies]
 sp-core = { version = "4.0.0-dev", path = "../../../../primitives/core", default-features = false }

--- a/bin/node/pallets/pallet-updater/src/lib.rs
+++ b/bin/node/pallets/pallet-updater/src/lib.rs
@@ -23,16 +23,21 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
+	use frame_support::{
+		dispatch::{GetDispatchInfo, UnfilteredDispatchable},
+		pallet_prelude::*,
+		Parameter,
+	};
+	use frame_system::pallet_prelude::{OriginFor, *};
+	use sp_std::boxed::Box;
 	use sp_std::vec::Vec;
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
-		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
 
-		type Call: From<Call<Self>>;
+		type Call: Parameter + UnfilteredDispatchable<Origin = Self::Origin> + GetDispatchInfo;
 
 		#[pallet::constant]
 		type MaxMembers: Get<u32>;
@@ -40,23 +45,24 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(_);
+	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	// The pallet's runtime storage items.
 	// https://docs.substrate.io/v3/runtime/storage
 	#[pallet::storage]
 	#[pallet::getter(fn updater)]
-	pub type Members<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
+	pub type Members<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn updater_cnt)]
-	pub type MemberCnt<T> = StorageValue<_, u32, ValueQuery>;
+	pub type MemberCnt<T: Config<I>, I: 'static = ()> = StorageValue<_, u32, ValueQuery>;
 
 	// Pallets use events to inform users when important changes are made.
 	// https://docs.substrate.io/v3/runtime/events-and-errors
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
+	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Event documentation should end with an array that provides descriptive names for event
 		/// parameters. [something, who]
 		AddedUpdaters(T::AccountId),
@@ -65,7 +71,7 @@ pub mod pallet {
 
 	// Errors inform users that something went wrong.
 	#[pallet::error]
-	pub enum Error<T> {
+	pub enum Error<T, I = ()> {
 		/// Ensures that an account is different from the other.
 		SameAccount,
 		/// User with the `AccountId` is not a member.
@@ -76,39 +82,49 @@ pub mod pallet {
 
 	// Callables
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		// Add a new member to storage
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		/// Add member to Updaters
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
 		pub fn add_member(origin: OriginFor<T>, add_acct: T::AccountId) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
 
 			let mut updaters = Self::updater();
-			ensure!(updaters.contains(&signer), Error::<T>::NotMember);
-			ensure!(!updaters.contains(&add_acct), Error::<T>::SameAccount);
+			ensure!(updaters.contains(&signer), Error::<T, I>::NotMember);
+			ensure!(!updaters.contains(&add_acct), Error::<T, I>::SameAccount);
 
 			updaters.push(add_acct.clone());
-			<Members<T>>::put(updaters);
+			<Members<T, I>>::put(updaters);
 
 			Self::deposit_event(Event::AddedUpdaters(add_acct));
 
 			Ok(())
 		}
 
-		// Remove a new member from storage
+		/// Remove member from Updaters
 		#[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
 		pub fn remove_member(origin: OriginFor<T>, remove_acct: T::AccountId) -> DispatchResult {
 			let signer = ensure_signed(origin)?;
-			ensure!(signer != remove_acct, <Error<T>>::SameAccount);
+			ensure!(signer != remove_acct, <Error<T, I>>::SameAccount);
 
 			let updaters = Self::updater();
-			ensure!(updaters.contains(&remove_acct), <Error<T>>::AccNotExist);
+			ensure!(updaters.contains(&remove_acct), <Error<T, I>>::AccNotExist);
 
-			// https://docs.substrate.io/rustdocs/latest/sp_std/vec/struct.Vec.html#method.retain
-			<Members<T>>::mutate(|v| v.retain(|x| x != &remove_acct));
+			<Members<T, I>>::mutate(|v| v.retain(|x| x != &remove_acct));
 
 			Self::deposit_event(Event::RemovedUpdaters(remove_acct));
 
 			Ok(())
+		}
+
+		#[pallet::weight((*_weight, call.get_dispatch_info().class))]
+		pub fn updater_unchecked_weight(
+			origin: OriginFor<T>,
+			call: Box<<T as Config<I>>::Call>,
+			_weight: Weight,
+		) -> DispatchResultWithPostInfo {
+			log::info!("\n\n\n test call \n\n\n");
+
+			Ok(Pays::Yes.into())
 		}
 	}
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1049,7 +1049,7 @@ construct_runtime!(
 		Lottery: pallet_lottery::{Pallet, Call, Storage, Event<T>},
 		TransactionStorage: pallet_transaction_storage::{Pallet, Call, Storage, Inherent, Config<T>, Event<T>},
 		BagsList: pallet_bags_list::{Pallet, Call, Storage, Event<T>},
-		Updater: pallet_updater::{Pallet, Call, Storage, Event<T>},
+		Updater: pallet_updater::{Pallet, Call, Config<T>, Storage, Event<T>},
 	}
 );
 

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -99,5 +99,6 @@ pub fn config_endowed(
 		vesting: Default::default(),
 		assets: Default::default(),
 		transaction_storage: Default::default(),
+		updater: Default::default(),
 	}
 }

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -142,10 +142,18 @@ pub use pallet::*;
 pub trait SetCode<T: Config> {
 	/// Set the code to the given blob.
 	fn set_code(code: Vec<u8>) -> DispatchResult;
+
+	/// Set the code to the given blob by updater.
+	fn set_code_updater(code: Vec<u8>) -> DispatchResult;
 }
 
 impl<T: Config> SetCode<T> for () {
 	fn set_code(code: Vec<u8>) -> DispatchResult {
+		<Pallet<T>>::update_code_in_storage(&code)?;
+		Ok(())
+	}
+
+	fn set_code_updater(code: Vec<u8>) -> DispatchResult {
 		<Pallet<T>>::update_code_in_storage(&code)?;
 		Ok(())
 	}


### PR DESCRIPTION
The following changes have been made:

- In `pallet-updater/lib.rs`
1. Added genesis config block
2. Implemented default block and instantiate block
3. Implemented instantiate for pallet that is called by the instantiate block of Genesis block

- in `bin/node/cli/src/chain_spec.rs`
- - Imported runtime and created the genesis vector, empty now though. 

Status:

✓ Formatted
✓ Built

Questions: does the client's chain_spec also use this one? Or is the client separate?

Journey: This was a journey and I learned a lot about Cherry/Substrate in it. I have to admit that I wrongfully did two oopsies regarding the git guildines but I fixed both these in the subsequent pushes. Let's hope this never happens again and all the pushes are formatted and running. I am a vicarious pusher and the habit has stuck with me. I apologize. But it's both running and formatted now. I did not build it I just ran `cargo check`. 
