### PR TITLE
fix: sudo origin for add_member and remove_member functions. Close_vo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6349,6 +6349,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "log 0.4.14",
  "parity-scale-codec",
  "scale-info",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -233,14 +233,12 @@ impl pallet_randomness_collective_flip::Config for Runtime {}
 parameter_types! {
 	/// Number of maximum members.
 	pub const MaxMemberCnt: u32 = 3;
-	pub const MaxProposalCnt: u32 = 1;
 	pub const UpdaterMotionDuration: BlockNumber = TECHNICAL_MOTION_DURATION;
 }
 
 impl pallet_updater::Config for Runtime {
 	type Event = Event;
 	type Call = Call;
-	type MaxProposals = MaxProposalCnt;
 	type MaxMembers = MaxMemberCnt;
 	type MotionDuration = UpdaterMotionDuration;
 }


### PR DESCRIPTION
Changed the origin of the ```add_member``` and ```remove_member``` functions from ```signed``` to ```sudo```.
Added a check to ```propose_code``` function so that we can only have 1 active proposal at a time.
Added a check to ```close_vote``` function so that it will give us an error if we try to close the vote before every member has casted their vote.