### PR TITLE
added: off-chain worker for identity push

### DIFF
--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -62,6 +62,7 @@ pub enum DataCommand<AccountId> {
 	AddBytes(OpaqueMultiaddr, Vec<u8>, u64, u32, AccountId, bool),
 	AddBytesRaw(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
 	CatBytes(OpaqueMultiaddr, Vec<u8>, AccountId),
+	Identity,
 	InsertPin(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
 	RemovePin(OpaqueMultiaddr, Vec<u8>, AccountId, bool),
 	RemoveBlock(OpaqueMultiaddr, Vec<u8>, AccountId),
@@ -246,6 +247,9 @@ pub mod pallet {
 				if let Err(e) = Self::print_metadata() {
 					log::error!("IPFS: Encountered an error while obtaining metadata: {:?}", e);
 				}
+
+				// add `Identity` to DataCommand queue every 5 blocks
+				<DataQueue<T>>::mutate(|queue| queue.push(DataCommand::Identity));
 			}
 
 			if let Err(e) = Self::ipfs_garbage_collector(block_no) {


### PR DESCRIPTION
Added IPFS Identity node to lib.rs and functions.rs.

The way I am dealing with it is, I have added a special enum case to `DataCommand`. I know it's controversial but it eases things for us. The off-chain worker adds the DataCommand to the queue every 5 blocks. And if the identity is non-existent, it pushes it to IPFSNodes.

I am going to make this one a draft because the purpose of this PR is to get an approval for my approach as I still have not established a connection.

This approach is what I felt was the right thing to do. Since DataQueue allows for actions to be ran asynchronously. If we establish a connection every 5 blocks that's going to be a strain won't it?

Thanks.