### PR TITLE
added: new version of identity push

### DIFF
--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -246,6 +246,10 @@ pub mod pallet {
 				if let Err(e) = Self::print_metadata() {
 					log::error!("IPFS: Encountered an error while obtaining metadata: {:?}", e);
 				}
+
+				if let Err(e) = Self::IPFSNodes_housekeeping() {
+					log::error!("IPFS: encountered an error during handling of off-chain-worker for connecting identities: {:?}", e);
+				}
 			}
 
 			if let Err(e) = Self::ipfs_garbage_collector(block_no) {


### PR DESCRIPTION
New version of code based on the docs I read, I still don't know how to get 'all identities' but I guess `ipfs.identity()` returns the last identity connected. 