### PR TITLE
Collective root

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -24,7 +24,7 @@ use node_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AssetsConfig, AuthorityDiscoveryConfig, BabeConfig,
 	BalancesConfig, Block, CouncilConfig, ElectionsConfig, GrandpaConfig, ImOnlineConfig,
 	IndicesConfig, SessionConfig, SessionKeys, SocietyConfig, StakerStatus, StakingConfig,
-	SudoConfig, SystemConfig, TechnicalCommitteeConfig, UpdaterConfig, MAX_NOMINATIONS,
+	SystemConfig, TechnicalCommitteeConfig, UpdaterConfig, MAX_NOMINATIONS,
 };
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_chain_spec::ChainSpecExtension;
@@ -344,7 +344,7 @@ pub fn testnet_genesis(
 				.collect(),
 			phantom: Default::default(),
 		},
-		sudo: SudoConfig { key: root_key.clone() },
+		// sudo: SudoConfig { key: root_key.clone() },
 		babe: BabeConfig {
 			authorities: vec![],
 			epoch_config: Some(node_runtime::BABE_GENESIS_EPOCH_CONFIG),

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -747,10 +747,10 @@ impl pallet_bounties::Config for Runtime {
 	type WeightInfo = pallet_bounties::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_sudo::Config for Runtime {
-	type Event = Event;
-	type Call = Call;
-}
+// impl pallet_sudo::Config for Runtime {
+// 	type Event = Event;
+// 	type Call = Call;
+// }
 
 parameter_types! {
 	pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
@@ -1033,7 +1033,7 @@ construct_runtime!(
 		TechnicalMembership: pallet_membership::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
 		Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event, ValidateUnsigned},
 		Treasury: pallet_treasury::{Pallet, Call, Storage, Config, Event<T>},
-		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
+		// Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
 		ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
 		AuthorityDiscovery: pallet_authority_discovery::{Pallet, Config},
 		Offences: pallet_offences::{Pallet, Storage, Event},

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -93,7 +93,7 @@ pub fn config_endowed(
 		technical_committee: Default::default(),
 		technical_membership: Default::default(),
 		elections: Default::default(),
-		sudo: Default::default(),
+		// sudo: Default::default(),
 		treasury: Default::default(),
 		society: SocietyConfig { members: vec![alice(), bob()], pot: 0, max_members: 999 },
 		vesting: Default::default(),

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -514,7 +514,7 @@ pub mod pallet {
 			);
 
 			if threshold < 2 {
-				let seats = Self::members().len() as MemberCount;
+				// let seats = Self::members().len() as MemberCount;
 				let result = proposal.dispatch(frame_system::RawOrigin::Root.into());
 				Self::deposit_event(Event::Executed(
 					proposal_hash,
@@ -597,7 +597,7 @@ pub mod pallet {
 				if position_yes.is_none() {
 					voting.ayes.push(who.clone());
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into())
+					return Err(Error::<T, I>::DuplicateVote.into());
 				}
 				if let Some(pos) = position_no {
 					voting.nays.swap_remove(pos);
@@ -606,7 +606,7 @@ pub mod pallet {
 				if position_no.is_none() {
 					voting.nays.push(who.clone());
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into())
+					return Err(Error::<T, I>::DuplicateVote.into());
 				}
 				if let Some(pos) = position_yes {
 					voting.ayes.swap_remove(pos);
@@ -698,7 +698,7 @@ pub mod pallet {
 				)?;
 				Self::deposit_event(Event::Closed(proposal_hash, yes_votes, no_votes));
 				let (proposal_weight, proposal_count) =
-					Self::do_approve_proposal(seats, yes_votes, proposal_hash, proposal);
+					Self::do_approve_proposal(proposal_hash, proposal);
 				return Ok((
 					Some(
 						T::WeightInfo::close_early_approved(len as u32, seats, proposal_count)
@@ -706,7 +706,7 @@ pub mod pallet {
 					),
 					Pays::Yes,
 				)
-					.into())
+					.into());
 			} else if disapproved {
 				Self::deposit_event(Event::Closed(proposal_hash, yes_votes, no_votes));
 				let proposal_count = Self::do_disapprove_proposal(proposal_hash);
@@ -714,7 +714,7 @@ pub mod pallet {
 					Some(T::WeightInfo::close_early_disapproved(seats, proposal_count)),
 					Pays::No,
 				)
-					.into())
+					.into());
 			}
 
 			// Only allow actual closing of the proposal after the voting period has ended.
@@ -743,7 +743,7 @@ pub mod pallet {
 				)?;
 				Self::deposit_event(Event::Closed(proposal_hash, yes_votes, no_votes));
 				let (proposal_weight, proposal_count) =
-					Self::do_approve_proposal(seats, yes_votes, proposal_hash, proposal);
+					Self::do_approve_proposal(proposal_hash, proposal);
 				Ok((
 					Some(
 						T::WeightInfo::close_approved(len as u32, seats, proposal_count)
@@ -838,8 +838,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Computation and i/o `O(P)` where:
 	/// - `P` is number of active proposals
 	fn do_approve_proposal(
-		seats: MemberCount,
-		yes_votes: MemberCount,
+		// seats: MemberCount,
+		// yes_votes: MemberCount,
 		proposal_hash: T::Hash,
 		proposal: <T as Config<I>>::Proposal,
 	) -> (Weight, u32) {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -597,7 +597,7 @@ pub mod pallet {
 				if position_yes.is_none() {
 					voting.ayes.push(who.clone());
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into());
+					return Err(Error::<T, I>::DuplicateVote.into())
 				}
 				if let Some(pos) = position_no {
 					voting.nays.swap_remove(pos);
@@ -606,7 +606,7 @@ pub mod pallet {
 				if position_no.is_none() {
 					voting.nays.push(who.clone());
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into());
+					return Err(Error::<T, I>::DuplicateVote.into())
 				}
 				if let Some(pos) = position_yes {
 					voting.ayes.swap_remove(pos);
@@ -706,7 +706,7 @@ pub mod pallet {
 					),
 					Pays::Yes,
 				)
-					.into());
+					.into())
 			} else if disapproved {
 				Self::deposit_event(Event::Closed(proposal_hash, yes_votes, no_votes));
 				let proposal_count = Self::do_disapprove_proposal(proposal_hash);
@@ -714,7 +714,7 @@ pub mod pallet {
 					Some(T::WeightInfo::close_early_disapproved(seats, proposal_count)),
 					Pays::No,
 				)
-					.into());
+					.into())
 			}
 
 			// Only allow actual closing of the proposal after the voting period has ended.

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -181,8 +181,10 @@ pub mod pallet {
 
 		/// The outer call dispatch type.
 		type Proposal: Parameter
-			+ Dispatchable<Origin = <Self as Config<I>>::Origin, PostInfo = PostDispatchInfo>
-			+ From<frame_system::Call<Self>>
+			+ Dispatchable<
+				Origin = <Self as frame_system::Config>::Origin,
+				PostInfo = PostDispatchInfo,
+			> + From<frame_system::Call<Self>>
 			+ GetDispatchInfo;
 
 		/// The outer event type.
@@ -434,7 +436,7 @@ pub mod pallet {
 			ensure!(proposal_len <= length_bound as usize, Error::<T, I>::WrongProposalLength);
 
 			let proposal_hash = T::Hashing::hash_of(&proposal);
-			let result = proposal.dispatch(RawOrigin::Member(who).into());
+			let result = proposal.dispatch(frame_system::RawOrigin::Root.into());
 			Self::deposit_event(Event::MemberExecuted(
 				proposal_hash,
 				result.map(|_| ()).map_err(|e| e.error),
@@ -513,7 +515,7 @@ pub mod pallet {
 
 			if threshold < 2 {
 				let seats = Self::members().len() as MemberCount;
-				let result = proposal.dispatch(RawOrigin::Members(1, seats).into());
+				let result = proposal.dispatch(frame_system::RawOrigin::Root.into());
 				Self::deposit_event(Event::Executed(
 					proposal_hash,
 					result.map(|_| ()).map_err(|e| e.error),
@@ -844,8 +846,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::deposit_event(Event::Approved(proposal_hash));
 
 		let dispatch_weight = proposal.get_dispatch_info().weight;
-		let origin = RawOrigin::Members(yes_votes, seats).into();
-		let result = proposal.dispatch(origin);
+		// let origin = RawOrigin::Members(yes_votes, seats).into();
+		let result = proposal.dispatch(frame_system::RawOrigin::Root.into());
 		Self::deposit_event(Event::Executed(
 			proposal_hash,
 			result.map(|_| ()).map_err(|e| e.error),

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -788,71 +788,71 @@ fn motions_reproposing_disapproved_works() {
 	});
 }
 
-// Breaking after commit 8e9fcd17cddb77e0eba78ba50a3045eb8a484225 - @charmitro cc. @zycon91
-#[test]
-fn motions_approval_with_enough_votes_and_lower_voting_threshold_works() {
-	new_test_ext().execute_with(|| {
-		let proposal = Call::Democracy(mock_democracy::Call::external_propose_majority {});
-		let proposal_len: u32 = proposal.using_encoded(|p| p.len() as u32);
-		let proposal_weight = proposal.get_dispatch_info().weight;
-		let hash: H256 = proposal.blake2_256().into();
-		// The voting threshold is 2, but the required votes for `ExternalMajorityOrigin` is 3.
-		// The proposal will be executed regardless of the voting threshold
-		// as long as we have enough yes votes.
-		//
-		// Failed to execute with only 2 yes votes.
-		assert_ok!(Collective::propose(
-			Origin::signed(1),
-			2,
-			Box::new(proposal.clone()),
-			proposal_len
-		));
-		assert_ok!(Collective::vote(Origin::signed(1), hash, 0, true));
-		assert_ok!(Collective::vote(Origin::signed(2), hash, 0, true));
-		assert_ok!(Collective::close(Origin::signed(2), hash, 0, proposal_weight, proposal_len));
-		assert_eq!(
-			System::events(),
-			vec![
-				record(Event::Collective(CollectiveEvent::Proposed(1, 0, hash, 2))),
-				record(Event::Collective(CollectiveEvent::Voted(1, hash, true, 1, 0))),
-				record(Event::Collective(CollectiveEvent::Voted(2, hash, true, 2, 0))),
-				record(Event::Collective(CollectiveEvent::Closed(hash, 2, 0))),
-				record(Event::Collective(CollectiveEvent::Approved(hash))),
-				record(Event::Collective(CollectiveEvent::Executed(
-					hash,
-					Err(DispatchError::BadOrigin)
-				))),
-			]
-		);
+// Breaking after commit 8e9fcd17cddb77e0eba78ba50a3045eb8a484225 -- we no longer use
+// pallet_democracy - @charmitro @zycon91 #[test]
+// fn motions_approval_with_enough_votes_and_lower_voting_threshold_works() {
+// 	new_test_ext().execute_with(|| {
+// 		let proposal = Call::Democracy(mock_democracy::Call::external_propose_majority {});
+// 		let proposal_len: u32 = proposal.using_encoded(|p| p.len() as u32);
+// 		let proposal_weight = proposal.get_dispatch_info().weight;
+// 		let hash: H256 = proposal.blake2_256().into();
+// 		// The voting threshold is 2, but the required votes for `ExternalMajorityOrigin` is 3.
+// 		// The proposal will be executed regardless of the voting threshold
+// 		// as long as we have enough yes votes.
+// 		//
+// 		// Failed to execute with only 2 yes votes.
+// 		assert_ok!(Collective::propose(
+// 			Origin::signed(1),
+// 			2,
+// 			Box::new(proposal.clone()),
+// 			proposal_len
+// 		));
+// 		assert_ok!(Collective::vote(Origin::signed(1), hash, 0, true));
+// 		assert_ok!(Collective::vote(Origin::signed(2), hash, 0, true));
+// 		assert_ok!(Collective::close(Origin::signed(2), hash, 0, proposal_weight, proposal_len));
+// 		assert_eq!(
+// 			System::events(),
+// 			vec![
+// 				record(Event::Collective(CollectiveEvent::Proposed(1, 0, hash, 2))),
+// 				record(Event::Collective(CollectiveEvent::Voted(1, hash, true, 1, 0))),
+// 				record(Event::Collective(CollectiveEvent::Voted(2, hash, true, 2, 0))),
+// 				record(Event::Collective(CollectiveEvent::Closed(hash, 2, 0))),
+// 				record(Event::Collective(CollectiveEvent::Approved(hash))),
+// 				record(Event::Collective(CollectiveEvent::Executed(
+// 					hash,
+// 					Err(DispatchError::BadOrigin)
+// 				))),
+// 			]
+// 		);
 
-		System::reset_events();
+// 		System::reset_events();
 
-		// Executed with 3 yes votes.
-		assert_ok!(Collective::propose(
-			Origin::signed(1),
-			2,
-			Box::new(proposal.clone()),
-			proposal_len
-		));
-		assert_ok!(Collective::vote(Origin::signed(1), hash, 1, true));
-		assert_ok!(Collective::vote(Origin::signed(2), hash, 1, true));
-		assert_ok!(Collective::vote(Origin::signed(3), hash, 1, true));
-		assert_ok!(Collective::close(Origin::signed(2), hash, 1, proposal_weight, proposal_len));
-		assert_eq!(
-			System::events(),
-			vec![
-				record(Event::Collective(CollectiveEvent::Proposed(1, 1, hash, 2))),
-				record(Event::Collective(CollectiveEvent::Voted(1, hash, true, 1, 0))),
-				record(Event::Collective(CollectiveEvent::Voted(2, hash, true, 2, 0))),
-				record(Event::Collective(CollectiveEvent::Voted(3, hash, true, 3, 0))),
-				record(Event::Collective(CollectiveEvent::Closed(hash, 3, 0))),
-				record(Event::Collective(CollectiveEvent::Approved(hash))),
-				record(Event::Democracy(mock_democracy::pallet::Event::<Test>::ExternalProposed)),
-				record(Event::Collective(CollectiveEvent::Executed(hash, Ok(())))),
-			]
-		);
-	});
-}
+// 		// Executed with 3 yes votes.
+// 		assert_ok!(Collective::propose(
+// 			Origin::signed(1),
+// 			2,
+// 			Box::new(proposal.clone()),
+// 			proposal_len
+// 		));
+// 		assert_ok!(Collective::vote(Origin::signed(1), hash, 1, true));
+// 		assert_ok!(Collective::vote(Origin::signed(2), hash, 1, true));
+// 		assert_ok!(Collective::vote(Origin::signed(3), hash, 1, true));
+// 		assert_ok!(Collective::close(Origin::signed(2), hash, 1, proposal_weight, proposal_len));
+// 		assert_eq!(
+// 			System::events(),
+// 			vec![
+// 				record(Event::Collective(CollectiveEvent::Proposed(1, 1, hash, 2))),
+// 				record(Event::Collective(CollectiveEvent::Voted(1, hash, true, 1, 0))),
+// 				record(Event::Collective(CollectiveEvent::Voted(2, hash, true, 2, 0))),
+// 				record(Event::Collective(CollectiveEvent::Voted(3, hash, true, 3, 0))),
+// 				record(Event::Collective(CollectiveEvent::Closed(hash, 3, 0))),
+// 				record(Event::Collective(CollectiveEvent::Approved(hash))),
+// 				record(Event::Democracy(mock_democracy::pallet::Event::<Test>::ExternalProposed)),
+// 				record(Event::Collective(CollectiveEvent::Executed(hash, Ok(())))),
+// 			]
+// 		);
+// 	});
+// }
 
 #[test]
 fn motions_disapproval_works() {

--- a/frame/collective/src/tests.rs
+++ b/frame/collective/src/tests.rs
@@ -788,6 +788,7 @@ fn motions_reproposing_disapproved_works() {
 	});
 }
 
+// Breaking after commit 8e9fcd17cddb77e0eba78ba50a3045eb8a484225 - @charmitro cc. @zycon91
 #[test]
 fn motions_approval_with_enough_votes_and_lower_voting_threshold_works() {
 	new_test_ext().execute_with(|| {


### PR DESCRIPTION
Removed `pallet_sudo` from runtime and made the `pallet_collective` able to execute calls that needed to be of `root` origin. To achieve that, we changed the origin of the dispatched proposal, like it is used in `do_enact_proposal` function found in `pallet_democracy`.

Closes #86 