### PR TITLE
Proposal changes

### DIFF
--- a/bin/node/pallets/pallet-council/src/lib.rs
+++ b/bin/node/pallets/pallet-council/src/lib.rs
@@ -636,7 +636,7 @@ pub mod pallet {
 					voting.ayes.push(who.clone());
 					voting.ayes_power.push((who.clone(), vote_power));
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into());
+					return Err(Error::<T, I>::DuplicateVote.into())
 				}
 				if let Some(pos) = position_no {
 					voting.nays.swap_remove(pos);
@@ -647,7 +647,7 @@ pub mod pallet {
 					voting.nays.push(who.clone());
 					voting.nays_power.push((who.clone(), vote_power));
 				} else {
-					return Err(Error::<T, I>::DuplicateVote.into());
+					return Err(Error::<T, I>::DuplicateVote.into())
 				}
 				if let Some(pos) = position_yes {
 					voting.ayes.swap_remove(pos);
@@ -783,7 +783,7 @@ pub mod pallet {
 					),
 					Pays::Yes,
 				)
-					.into());
+					.into())
 			} else if disapproved {
 				Self::deposit_event(Event::Closed(proposal_hash, yes_power, no_power));
 				let proposal_count = Self::do_disapprove_proposal(proposal_hash);
@@ -794,7 +794,7 @@ pub mod pallet {
 					)),
 					Pays::No,
 				)
-					.into());
+					.into())
 			}
 
 			// Only allow actual closing of the proposal after the voting period has ended.
@@ -992,7 +992,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			max_gov_tokens += vote_power;
 		}
 
-		return max_gov_tokens;
+		return max_gov_tokens
 	}
 }
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -130,9 +130,11 @@ pub struct Proposal<AccountId, Balance> {
 	/// The amount held on deposit (reserved) for making this proposal.
 	bond: Balance,
 	/// How many times should this be repeated.
-	occurs: u32,
+	segments: u32,
 	/// How many times left to be repeated.
 	remaining_occurs: u32,
+	/// In which cycle the proposal will be active (True = current cycle, False = next cycle).
+	cycle: bool,
 }
 
 #[frame_support::pallet]
@@ -350,19 +352,22 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] value: BalanceOf<T, I>,
 			beneficiary: <T::Lookup as StaticLookup>::Source,
-			occurs: u32,
+			segments: u32,
+			cycle: bool,
 		) -> DispatchResult {
 			let proposer = ensure_signed(origin)?;
 			let beneficiary = T::Lookup::lookup(beneficiary)?;
 
 			let current_block = <frame_system::Pallet<T>>::block_number();
 
-			if (current_block % T::SpendPeriod::get()).lt(&T::AllowedProposalPeriod::get()) {
+			if (current_block % T::SpendPeriod::get()).lt(&T::AllowedProposalPeriod::get()) &&
+				cycle == true
+			{
 				let chunk: <<T as Config<I>>::Currency as Currency<
 					<T as frame_system::Config>::AccountId,
 				>>::Balance;
-				if occurs.gt(&0) {
-					chunk = value / occurs.into();
+				if segments.gt(&0) {
+					chunk = value / segments.into();
 				} else {
 					chunk = value;
 				}
@@ -380,8 +385,9 @@ pub mod pallet {
 						value: chunk.clone(),
 						beneficiary: beneficiary.clone(),
 						bond,
-						occurs,
-						remaining_occurs: occurs,
+						segments,
+						remaining_occurs: segments,
+						cycle,
 					},
 				);
 
@@ -390,8 +396,8 @@ pub mod pallet {
 				let chunk: <<T as Config<I>>::Currency as Currency<
 					<T as frame_system::Config>::AccountId,
 				>>::Balance;
-				if occurs.gt(&0) {
-					chunk = value / occurs.into();
+				if segments.gt(&0) {
+					chunk = value / segments.into();
 				} else {
 					chunk = value;
 				}
@@ -408,8 +414,9 @@ pub mod pallet {
 						value: chunk.clone(),
 						beneficiary: beneficiary.clone(),
 						bond,
-						occurs,
-						remaining_occurs: occurs,
+						segments,
+						remaining_occurs: segments,
+						cycle,
 					},
 				);
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -516,7 +516,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 							p.remaining_occurs = p.remaining_occurs - 1;
 						}
 
-						if p.remaining_occurs.le(&0) {
+						if p.remaining_occurs.le(&0) && p.segments.gt(&0) {
 							<Proposals<T, I>>::remove(index);
 						} else {
 							<Proposals<T, I>>::remove(index);
@@ -532,8 +532,21 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						Self::deposit_event(Event::Awarded(index, p.value, p.beneficiary.clone()));
 						false
 					} else {
+						if p.remaining_occurs.gt(&0) {
+							p.remaining_occurs = p.remaining_occurs - 1;
+							<Proposals<T, I>>::remove(index);
+							<Proposals<T, I>>::insert(index, p.clone());
+						} else {
+							<Proposals<T, I>>::remove(index);
+							<Proposals<T, I>>::insert(index, p.clone());
+						}
+
+						if p.remaining_occurs.eq(&0) && p.segments.gt(&0) {
+							<Proposals<T, I>>::remove(index);
+						}
+
 						missed_any = true;
-						true
+						false
 					}
 				} else {
 					false


### PR DESCRIPTION
We need to implement the following things in `pallet_treasury` proposals.

**Proposal Changes**

- [x] Add a cycle field to the `propose_spend` function. A user should be able to choose if he wants to propose for this cycle or the next (or any future cycles).
- [x] If a proposal (non-recurring) gets approved, but the treasury cannot fund it, the proposal will be rolled over the next spend period, but the votes will become NULL.
- [x] If a recurring proposal gets approved, but the treasury cannot fund a segment of it in a spend period, the proposal will lose that segment.