### PR TITLE
fix: proposal (non-recurring) getting removed after getting funded.

### DIFF
--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -516,7 +516,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 							p.remaining_occurs = p.remaining_occurs - 1;
 						}
 
-						if p.remaining_occurs.le(&0) && p.segments.gt(&0) {
+						if p.remaining_occurs.le(&0) {
 							<Proposals<T, I>>::remove(index);
 						} else {
 							<Proposals<T, I>>::remove(index);


### PR DESCRIPTION
Non-recurring proposals weren't removed from the storage after getting funded. One of the conditions was messing with it. Removed the condition and ran some tests and everything works as it should.