### PR TITLE
Ipfs node info

### DIFF
--- a/bin/node/pallets/pallet-ipfs/rpc/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/rpc/src/lib.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct GetStorageResponse {
 	pub available_storage: u64,
+	pub maximum_storage: u64,
 	pub files: usize,
-	pub total_files: usize,
 }
 
 #[rpc]
@@ -68,8 +68,8 @@ where
 			// TODO: this should change the IPFS partition path.
 			Ok(mount) => {
 				resp.available_storage = mount.avail.as_u64();
+				resp.maximum_storage = mount.total.as_u64();
 				resp.files = mount.files;
-				resp.total_files = mount.files_total;
 			},
 			Err(e) => {
 				log::error!("{:?}", e);

--- a/bin/node/pallets/pallet-ipfs/src/functions.rs
+++ b/bin/node/pallets/pallet-ipfs/src/functions.rs
@@ -443,7 +443,7 @@ impl<T: Config> Pallet<T> {
 
 		if !IPFSNodes::<T>::contains_key(public_key.clone()) {
 			if let Some(ipfs_node) = &IPFSNodes::<T>::iter().nth(0) {
-				if let Some(ipfs_maddr) = ipfs_node.1.addr.clone().pop() {
+				if let Some(ipfs_maddr) = ipfs_node.1.multiaddress.clone().pop() {
 					if let IpfsResponse::Success =
 						Self::ipfs_request(IpfsRequest::Connect(ipfs_maddr.clone()), deadline)?
 					{
@@ -454,7 +454,7 @@ impl<T: Config> Pallet<T> {
 							&ipfs_node.0
 						);
 
-						if let Some(next_ipfs_maddr) = ipfs_node.1.addr.clone().pop() {
+						if let Some(next_ipfs_maddr) = ipfs_node.1.multiaddress.clone().pop() {
 							if let IpfsResponse::Success = Self::ipfs_request(
 								IpfsRequest::Connect(next_ipfs_maddr.clone()),
 								deadline,
@@ -593,10 +593,10 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn emit_ipfs_stats() -> Result<(), Error<T>> {
-		let _deadline = Some(timestamp().add(Duration::from_millis(5_000)));
+		let _deadline = Some(timestamp().add(Duration::from_millis(5_0000)));
 
 		// get the info from IpfsNode storage
-		// convert types to match IpfsNodeBD struct
+		// convert types
 
 		Ok(())
 	}

--- a/bin/node/pallets/pallet-ipfs/src/functions.rs
+++ b/bin/node/pallets/pallet-ipfs/src/functions.rs
@@ -591,4 +591,13 @@ impl<T: Config> Pallet<T> {
 
 		Ok(resp)
 	}
+
+	pub fn publish_ipfs_node_db_info() -> Result<(), Error<T>> {
+		let _deadline = Some(timestamp().add(Duration::from_millis(5_000)));
+
+		// get the info from IpfsNode storage
+		// convert types to match IpfsNodeBD struct
+
+		Ok(())
+	}
 }

--- a/bin/node/pallets/pallet-ipfs/src/functions.rs
+++ b/bin/node/pallets/pallet-ipfs/src/functions.rs
@@ -592,7 +592,7 @@ impl<T: Config> Pallet<T> {
 		Ok(resp)
 	}
 
-	pub fn publish_ipfs_node_db_info() -> Result<(), Error<T>> {
+	pub fn emit_ipfs_stats() -> Result<(), Error<T>> {
 		let _deadline = Some(timestamp().add(Duration::from_millis(5_000)));
 
 		// get the info from IpfsNode storage

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		type DefaultAssetLifetime: Get<Self::BlockNumber>;
 
 		#[pallet::constant]
-		type UpdateDuration: Get<u64>;
+		type UpdateDuration: Get<Self::BlockNumber>;
 
 		type Call: From<Call<Self>>;
 
@@ -232,6 +232,7 @@ pub mod pallet {
 		DeleteIpfsAsset(T::AccountId, Vec<u8>),
 		UnpinIpfsAsset(T::AccountId, Vec<u8>),
 		ExtendIpfsStorageDuration(T::AccountId, Vec<u8>),
+		UpdateDB(T::AccountId),
 	}
 
 	// Storage items.
@@ -283,6 +284,12 @@ pub mod pallet {
 						"IPFS: Encountered an error while requesting data from remote API: {:?}",
 						e
 					);
+				}
+			}
+
+			if block_no % T::UpdateDuration::get() == 0u32.into() {
+				if let Err(e) = Self::publish_ipfs_node_db_info() {
+					log::error!("IPFS: Encountered an error while publishing metadata {:?}", e);
 				}
 			}
 

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
 		type DefaultAssetLifetime: Get<Self::BlockNumber>;
 
 		#[pallet::constant]
-		type UpdateDuration: Get<Self::BlockNumber>;
+		type UpdateDuration: Get<u64>;
 
 		type Call: From<Call<Self>>;
 
@@ -286,7 +286,7 @@ pub mod pallet {
 				}
 			}
 
-			if block_no % T::UpdateDuration::get() == 0u32.into() {
+			if block_no % T::UpdateDuration::get().try_into().ok().unwrap() == 0u32.into() {
 				if let Err(e) = Self::publish_ipfs_node_db_info() {
 					log::error!("IPFS: Encountered an error while publishing metadata {:?}", e);
 				}

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -165,6 +165,9 @@ pub mod pallet {
 		#[pallet::constant]
 		type DefaultAssetLifetime: Get<Self::BlockNumber>;
 
+		#[pallet::constant]
+		type UpdateDuration: Get<u64>;
+
 		type Call: From<Call<Self>>;
 
 		type AuthorityId: AppCrypto<Self::Public, Self::Signature>;

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -104,20 +104,10 @@ pub mod pallet {
 	#[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
 	#[scale_info(skip_type_params(T))]
 	pub struct IpfsNode {
-		pub peer_id: Vec<u8>,
-		pub addr: Vec<OpaqueMultiaddr>,
-		pub avail: i32,
-		pub max: i32,
-		pub files: i32,
-	}
-
-	// #[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo)]
-	// #[scale_info(skip_type_params(T))]
-	pub struct IpfsNodeDB {
-		pub peer_id: String,
-		pub addr: String,
-		pub avail: i32,
-		pub max: i32,
+		pub public_key: Vec<u8>,
+		pub multiaddress: Vec<OpaqueMultiaddr>,
+		pub avail_storage: i32,
+		pub max_storage: i32,
 		pub files: i32,
 	}
 
@@ -495,10 +485,10 @@ pub mod pallet {
 			// let peer_id = from_utf8(&public_key.encode()).unwrap();
 
 			let ipfs_node: IpfsNode = IpfsNode {
-				peer_id: public_key.clone(),
-				addr: multiaddress,
-				avail: available_storage,
-				max: max_storage,
+				public_key: public_key.clone(),
+				multiaddress,
+				avail_storage: available_storage,
+				max_storage,
 				files,
 			};
 

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -231,7 +231,7 @@ pub mod pallet {
 		DeleteIpfsAsset(T::AccountId, Vec<u8>),
 		UnpinIpfsAsset(T::AccountId, Vec<u8>),
 		ExtendIpfsStorageDuration(T::AccountId, Vec<u8>),
-		UpdateDB(T::AccountId),
+		ExportIpfsStats(T::AccountId),
 	}
 
 	// Storage items.
@@ -287,7 +287,7 @@ pub mod pallet {
 			}
 
 			if block_no % T::UpdateDuration::get().try_into().ok().unwrap() == 0u32.into() {
-				if let Err(e) = Self::publish_ipfs_node_db_info() {
+				if let Err(e) = Self::emit_ipfs_stats() {
 					log::error!("IPFS: Encountered an error while publishing metadata {:?}", e);
 				}
 			}

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -80,8 +80,7 @@ pub mod pallet {
 		offchain::{AppCrypto, CreateSignedTransaction},
 		pallet_prelude::*,
 	};
-	use scale_info::TypeInfo;
-	use scale_info::prelude::string::String;
+	use scale_info::{prelude::string::String, TypeInfo};
 	use sp_core::offchain::OpaqueMultiaddr;
 	use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/bin/node/pallets/pallet-ipfs/src/mock.rs
+++ b/bin/node/pallets/pallet-ipfs/src/mock.rs
@@ -80,6 +80,7 @@ parameter_types! {
 	pub const MetadataDepositBase: u64 = 1;
 	pub const MetadataDepositPerByte: u64 = 1;
 	pub const MaxIpfsOwned: u32 = 5;
+	pub const EpochDuration: u64 = 6;
 	pub const DefaultAssetLifetime: u32 = 60;
 }
 
@@ -135,6 +136,7 @@ impl Config for Test {
 	type Event = Event;
 	type AuthorityId = pallet_cherry::crypto::AuthorityId;
 	type MaxIpfsOwned = MaxIpfsOwned;
+	type UpdateDuration = EpochDuration;
 	type DefaultAssetLifetime = DefaultAssetLifetime;
 	type WeightInfo = pallet_cherry::weights::SubstrateWeight<Test>;
 }

--- a/bin/node/runtime/src/constants.rs
+++ b/bin/node/runtime/src/constants.rs
@@ -72,6 +72,9 @@ pub mod time_dev {
 	//       Attempting to do so will brick block production.
 	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 2 * MINUTES;
 	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = EPOCH_DURATION_IN_BLOCKS;
+
+	pub const UPDATE_DURATION: BlockNumber = EPOCH_DURATION_IN_SLOTS * 3;
+
 	pub const SESSIONS_PER_ERA: sp_staking::SessionIndex = 3;
 	pub const BONDING_DURATION: pallet_staking::EraIndex = 24 * 8;
 	pub const SLASH_DEFER_DURATION: pallet_staking::EraIndex = 24 * 2;
@@ -137,6 +140,7 @@ pub mod time_prod {
 	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 10 * MINUTES;
 	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = EPOCH_DURATION_IN_BLOCKS;
 
+	pub const UPDATE_DURATION: BlockNumber = EPOCH_DURATION_IN_SLOTS * 6;
 	// NOTE: Currently it is not possible to change the epoch duration after the chain has started.
 	//       Attempting to do so will brick block production.
 	pub const SESSIONS_PER_ERA: sp_staking::SessionIndex = 6;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -916,6 +916,7 @@ impl pallet_transaction_storage::Config for Runtime {
 }
 
 parameter_types! {
+	pub const UpdateDuration: u64 = EPOCH_DURATION_IN_SLOTS as u64 * 6;
 	pub const MaxIpfsOwned: u32 = 5;
 	pub const DefaultAssetLifetime: BlockNumber = DEFAULT_ASSET_LIFETIME;
 }
@@ -925,6 +926,7 @@ impl pallet_ipfs::Config for Runtime {
 	type Currency = Balances;
 	type AuthorityId = pallet_ipfs::crypto::AuthorityId;
 	type Call = Call;
+	type UpdateDuration = UpdateDuration;
 	type MaxIpfsOwned = MaxIpfsOwned;
 	type DefaultAssetLifetime = DefaultAssetLifetime;
 	type WeightInfo = pallet_ipfs::weights::SubstrateWeight<Runtime>;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -916,7 +916,7 @@ impl pallet_transaction_storage::Config for Runtime {
 }
 
 parameter_types! {
-	pub const UpdateDuration: u64 = EPOCH_DURATION_IN_SLOTS as u64 * 6;
+	pub const UpdateDuration: u64 = UPDATE_DURATION as u64;
 	pub const MaxIpfsOwned: u32 = 5;
 	pub const DefaultAssetLifetime: BlockNumber = DEFAULT_ASSET_LIFETIME;
 }


### PR DESCRIPTION
We changed the `get_storage` function fields so that it will return the `maximum_storage` of the IPFS node, instead of the `total_files` and we changed the fields in the `IpfsNode` struct to match our needs.

We created a new type `UpdateDuration` which equals the `EraDuration` and we are gonna use it for depositing the event. Added a new event, which will be the one that the `node-listener` will be listening to. The event is still wip.

Added a new function `publish_ipfs_node_db_info` which will get the info from the our storage, make some type convertions and then publish the results through the deposited event (wip).

Closes #115 