### PR TITLE
fix: storage types and multiaddr conversion

### DIFF
--- a/bin/node/pallets/pallet-ipfs/src/functions.rs
+++ b/bin/node/pallets/pallet-ipfs/src/functions.rs
@@ -603,10 +603,10 @@ impl<T: Config> Pallet<T> {
 		let node = Self::ipfs_nodes(&public_key).ok_or(<Error<T>>::IpfsNodeNotExist)?;
 
 		// convert types
-		let item_addr = from_utf8(&node.multiaddress.encode()).unwrap().as_bytes().to_vec();
+		let item_addr = node.multiaddress.encode();
 		let item_peer_id = node.public_key;
-		let avail = node.avail_storage as i32;
-		let max = node.max_storage as i32;
+		let avail = node.avail_storage as i64;
+		let max = node.max_storage as i64;
 		let files = node.files as i32;
 
 		// emit event

--- a/bin/node/pallets/pallet-ipfs/src/lib.rs
+++ b/bin/node/pallets/pallet-ipfs/src/lib.rs
@@ -222,7 +222,7 @@ pub mod pallet {
 		DeleteIpfsAsset(T::AccountId, Vec<u8>),
 		UnpinIpfsAsset(T::AccountId, Vec<u8>),
 		ExtendIpfsStorageDuration(T::AccountId, Vec<u8>),
-		ExportIpfsStats(T::AccountId, Vec<u8>, Vec<u8>, i32, i32, i32),
+		ExportIpfsStats(T::AccountId, Vec<u8>, Vec<u8>, i64, i64, i32),
 		SessionResults(T::AccountId, Vec<u8>, BalanceOf<T>),
 	}
 
@@ -602,8 +602,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			peer_id: Vec<u8>,
 			multiaddress: Vec<u8>,
-			avail_storage: i32,
-			max_storage: i32,
+			avail_storage: i64,
+			max_storage: i64,
 			files: i32,
 		) -> DispatchResult {
 			let signer = ensure_signed(origin)?;


### PR DESCRIPTION
Changed the types of `avail` and `max` to match the `node-listener` types. Closes #121 

Co-Authored-By: Martín Noblía <mnoblia@disroot.org>

