### PR TITLE
Fix bonding duration

### DIFF
--- a/bin/node/runtime/src/constants.rs
+++ b/bin/node/runtime/src/constants.rs
@@ -138,19 +138,19 @@ pub mod time_prod {
 	// NOTE: Currently it is not possible to change the epoch duration after the chain has started.
 	//       Attempting to do so will brick block production.
 	pub const SESSIONS_PER_ERA: sp_staking::SessionIndex = 6;
-	pub const BONDING_DURATION: pallet_staking::EraIndex = 24 * 28;
-	pub const SLASH_DEFER_DURATION: pallet_staking::EraIndex = 24 * 27;
+	pub const BONDING_DURATION: pallet_staking::EraIndex = 6 * 28;
+	pub const SLASH_DEFER_DURATION: pallet_staking::EraIndex = 5* 28;
 	pub const REPORT_LONGEVITY: u64 =
 		BONDING_DURATION as u64 * SESSIONS_PER_ERA as u64 * EPOCH_DURATION_IN_SLOTS as u64;
 
 	pub const TERM_DURATION: BlockNumber = 7 * DAYS;
 	pub const COUNCIL_MOTION_DURATION: BlockNumber = 5 * DAYS;
 	pub const TECHNICAL_MOTION_DURATION: BlockNumber = 5 * DAYS;
-	pub const ENACTMENT_PERIOD: BlockNumber = 30 * 24 * 60 * MINUTES;
-	pub const LAUNCH_PERIOD: BlockNumber = 28 * 24 * 60 * MINUTES;
-	pub const VOTING_PERIOD: BlockNumber = 28 * 24 * 60 * MINUTES;
-	pub const FAST_TRACK_VOTING_PERIOD: BlockNumber = 3 * 24 * 60 * MINUTES;
-	pub const COOLOFF_PERIOD: BlockNumber = 28 * 24 * 60 * MINUTES;
+	pub const ENACTMENT_PERIOD: BlockNumber = 30 * DAYS;
+	pub const LAUNCH_PERIOD: BlockNumber = 28 * DAYS;
+	pub const VOTING_PERIOD: BlockNumber = 28 * DAYS;
+	pub const FAST_TRACK_VOTING_PERIOD: BlockNumber = 3 * DAYS;
+	pub const COOLOFF_PERIOD: BlockNumber = 28 * DAYS;
 
 	pub const ALLOWED_PROPOSAL_PERIOD: BlockNumber = 24 * DAYS;
 	pub const SPEND_PERIOD: BlockNumber = 28 * DAYS;

--- a/bin/node/runtime/src/constants.rs
+++ b/bin/node/runtime/src/constants.rs
@@ -72,8 +72,8 @@ pub mod time_dev {
 	pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 2 * MINUTES;
 	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = EPOCH_DURATION_IN_BLOCKS;
 	pub const SESSIONS_PER_ERA: sp_staking::SessionIndex = 3;
-	pub const BONDING_DURATION: pallet_staking::EraIndex = 24 * 8;
-	pub const SLASH_DEFER_DURATION: pallet_staking::EraIndex = 24 * 2;
+	pub const BONDING_DURATION: pallet_staking::EraIndex = 6 * 28;
+	pub const SLASH_DEFER_DURATION: pallet_staking::EraIndex = 5 * 28;
 	pub const REPORT_LONGEVITY: u64 =
 		BONDING_DURATION as u64 * SESSIONS_PER_ERA as u64 * EPOCH_DURATION_IN_SLOTS as u64;
 

--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -37,10 +37,17 @@ mod multiplier_tests {
 	};
 
 	use crate::{
-		constants::{currency::*, time::*},
+		constants::currency::*,
 		AdjustmentVariable, MinimumMultiplier, Runtime, RuntimeBlockWeights as BlockWeights,
 		System, TargetBlockFullness, TransactionPayment,
 	};
+
+	#[cfg(not(feature = "dev"))]
+	use constants::time_prod::*;
+	
+	#[cfg(feature = "dev")]
+	use constants::time_dev::*;
+
 	use frame_support::weights::{DispatchClass, Weight, WeightToFeePolynomial};
 
 	fn max_normal() -> Weight {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -126,7 +126,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 273,
+	spec_version: 274,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Fix the `Bonding Duration` to be 28 days and cleaned up other constants as well. Tested the runtime upgrade on Testnet and worked with no problems.